### PR TITLE
В delivery_recipient_cost теперь может быть нулевое значение

### DIFF
--- a/src/Entity/Requests/Order.php
+++ b/src/Entity/Requests/Order.php
@@ -239,9 +239,9 @@ class Order extends Source
      *
      * @return self
      */
-    public function setDeliveryRecipientCost($value, $vat_sum = null, $vat_rate = null)
+    public function setDeliveryRecipientCost(float $value = 0.0, $vat_sum = null, $vat_rate = null)
     {
-        if (!empty($value)) {
+        if (is_float($value)) {
             $args = \get_defined_vars();
             $this->delivery_recipient_cost = Money::express($args);
         }

--- a/src/Entity/Requests/Source.php
+++ b/src/Entity/Requests/Source.php
@@ -45,7 +45,9 @@ class Source implements JsonSerializable
                 }
             } else {
                 $a = \get_object_vars($this->{$key});
-                $dynamic[$key] = \array_filter($a);
+                $dynamic[$key] = \array_filter($a, function ($value) {
+                    return $value !== null;
+                });
             }
         }
 


### PR DESCRIPTION
Я столкнулся с проблемой, что мне нужно в качестве цены за доставку указать нулевое значение.

В src/Entity/Requests/Order.php если $value нулевое значение, определяет как пустое. Поэтому поменял на float с предустановленным 0.0

В src/Entity/Requests/Source.php все нулевые значения удалялись из объекта Money, добавил коллбэк для строгого поиска не NULL значений