### PR TITLE
Возможность обновлять состав заказа

### DIFF
--- a/src/Entity/Responses/PackagesResponse.php
+++ b/src/Entity/Responses/PackagesResponse.php
@@ -15,13 +15,6 @@ class PackagesResponse extends Source
 {
     use PackageTrait;
     /**
-     *Уникальный номер упаковки в ИС СДЭК.
-     *
-     * @var string
-     */
-    protected $package_id;
-
-    /**
      * Объемный вес (в граммах).
      *
      * @var int
@@ -53,15 +46,5 @@ class PackagesResponse extends Source
     public function getWeightCalc()
     {
         return $this->weight_calc;
-    }
-
-    /**
-     * Получить значение - Уникальный номер упаковки в ИС СДЭК.
-     *
-     * @return string
-     */
-    public function getPackageId()
-    {
-        return $this->package_id;
     }
 }

--- a/src/Traits/PackageTrait.php
+++ b/src/Traits/PackageTrait.php
@@ -21,6 +21,13 @@ trait PackageTrait
     protected $number;
 
     /**
+     * ID упаковки
+     *
+     * @var string
+     */
+    protected $package_id;
+
+    /**
      * Общий вес (в граммах).
      *
      * @var int
@@ -74,6 +81,24 @@ trait PackageTrait
         $this->number = $number;
 
         return $this;
+    }
+
+     /**
+     * Устанавливает ID упаковки
+     */
+    public function setPackageId(string $packageId): self
+    {
+        $this->package_id = $packageId;
+
+        return $this;
+    }
+
+    /**
+     * Получить ID упаковки
+     */
+    public function getPackageId(): ?string
+    {
+        return $this->package_id;
     }
 
     /**


### PR DESCRIPTION
При попытке обновить зарегистрированный заказ получаю ошибку. От API CDEK при вызове orders получена ошибка: Не передан идентификатор уже существующей упаковки заказа. Package_id for {order_number} package is empty.

В документации написано, что параметр package_id обязателен при обновлении заказа:
![image](https://user-images.githubusercontent.com/36367057/176883458-0ecf0ee0-a91d-44e5-b700-526934a0a5aa.png)

ссылка на доку:
https://api-docs.cdek.ru/36981178.html