### PR TITLE
Добавил возможность указать код ТН ВЭД для товаров

### DIFF
--- a/src/Traits/ItemTrait.php
+++ b/src/Traits/ItemTrait.php
@@ -112,6 +112,13 @@ trait ItemTrait
     protected $url;
 
     /**
+     * Код ТН ВЭД для международных заказов
+     *
+     * @var string
+     */
+    protected $feacn_code;
+
+    /**
      * Устанавливает наименование товара.
      *
      * @param string $name Наименование товара
@@ -313,6 +320,20 @@ trait ItemTrait
     }
 
     /**
+     * Устанавливает Код ТН ВЭД.
+     *
+     * @param string $feacn_code Код ТН ВЭД
+     *
+     * @return self
+     */
+    public function setFeacnCode(string $feacn_code)
+    {
+        $this->feacn_code = $feacn_code;
+
+        return $this;
+    }
+
+    /**
      * Get наименование товара.
      *
      * @return string
@@ -460,5 +481,15 @@ trait ItemTrait
     public function getUrl()
     {
         return $this->url;
+    }
+
+    /**
+     * Get Код ТН ВЭД
+     *
+     * @return string
+     */
+    public function getFeacnCode()
+    {
+        return $this->feacn_code;
     }
 }


### PR DESCRIPTION
Добавлена поддержка кода ТН ВЭД (feacn_code) для международных заказов.

Клиент теперь может передавать код ТН ВЭД для товаров при создании международного заказа, что является обязательным требованием СДЭК.  
Реализация добавлена в трейт `AntistressStore\CdekSDK2\Traits\ItemTrait`.